### PR TITLE
03 system spec)  ModelSpec的記述→SystemSpec的記述へ修正

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,4 +58,5 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.action_controller.allow_forgery_protection = false
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,4 +91,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.action_controller.allow_forgery_protection = false
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,25 +1,9 @@
 FactoryBot.define do
-  factory :task, class: Task do
-    id { 1 }
-    # idを指定しない状態だとexpect(current_path).to eq task_path(task)が通らないため追加
-    title { 'ランニング' }
-    content { 'A公園' }
-    status { 0 }
-    deadline { '2020-6-20 7:00' }
-    
-    association :user,
-      factory: :user,
-      email: 'test1@example.com'
-  end
-
-  factory :re_task, class: Task do
-    title { 'ランニング' }
-    content { 'A公園' }
-    status { 0 }
-    deadline { '2020-6-20 7:00' }
-    
-    association :user,
-      factory: :user,
-      email: 'test2@example.com'
+  factory :task do
+    sequence(:title) { |n| "title#{n}" }
+    content { 'content' }
+    status {:todo}
+    deadline { 1.week.from_now }
+    association :user
   end
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     sequence(:title) { |n| "title#{n}" }
     content { 'content' }
     status {:todo}
-    deadline { 1.week.from_now }
+    deadline { 1.week.from_now.strftime('%Y/%-m/%-d %-H:%-M') }
     association :user
   end
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
       factory: :user,
       email: 'test1@example.com'
   end
-    
+
   factory :re_task, class: Task do
     title { 'ランニング' }
     content { 'A公園' }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :user, class: User do
+    id { 1 }
     email { 'test@example.com' }
     password { 'pwd' }
     password_confirmation { 'pwd' }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,6 +5,13 @@ FactoryBot.define do
     password { 'pwd' }
     password_confirmation { 'pwd' }
   end
+  
+  factory :re_user, class: User do
+    id { 2 }
+    email { 'test@example.com' }
+    password { 'pwd' }
+    password_confirmation { 'pwd' }
+  end
 
   factory :edited_user, class: User do
     email { 'edited@example.com' }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,28 +1,7 @@
 FactoryBot.define do
   factory :user, class: User do
-    id { 1 }
-    email { 'test@example.com' }
-    password { 'pwd' }
-    password_confirmation { 'pwd' }
-  end
-  
-  factory :re_user, class: User do
-    id { 2 }
-    email { 'test@example.com' }
-    password { 'pwd' }
-    password_confirmation { 'pwd' }
-  end
-
-  factory :other_user, class: User do
-    id { 2 }
-    email { 'test2@example.com' }
-    password { 'pwd' }
-    password_confirmation { 'pwd' }
-  end
-
-  factory :edited_user, class: User do
-    email { 'edited@example.com' }
-    password { 'edited_pwd' }
-    password_confirmation { 'edited_pwd' }
+    sequence(:email) {|n| "test#{n}@example.com"}
+    password { 'password' }
+    password_confirmation { 'password' }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -13,6 +13,13 @@ FactoryBot.define do
     password_confirmation { 'pwd' }
   end
 
+  factory :other_user, class: User do
+    id { 2 }
+    email { 'test2@example.com' }
+    password { 'pwd' }
+    password_confirmation { 'pwd' }
+  end
+
   factory :edited_user, class: User do
     email { 'edited@example.com' }
     password { 'edited_pwd' }

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,3 +1,4 @@
+# dammy commnet for dammy push
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,4 +65,7 @@ RSpec.configure do |config|
 
   # カスタムモジュールLoginModuleの読込
   config.include LoginModule
+
+  # 省略記法を用いる
+  config.include FactoryBot::Syntax::Methods
 end

--- a/spec/support/login_module.rb
+++ b/spec/support/login_module.rb
@@ -5,7 +5,7 @@ module LoginModule
 
     # ログイン情報を入力
     fill_in 'Email', with: user.email
-    fill_in 'Password', with: 'pwd'
+    fill_in 'Password', with: 'password'
 
     # ログイン情報を送信
     click_button 'Login'

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -1,161 +1,259 @@
 require 'rails_helper'
 
-RSpec.describe "Tasks", type: :system do
-  describe '#index' do
-    it 'populates an array of tasks created by login-user' do
-      # ログインする
-      login_user = FactoryBot.create(:user) # id=1のuser
-      login(login_user)
-      sleep 1
-
-      # login_userが作成したタスクを用意
-      task_by_login_user = FactoryBot.create(:task, user_id: 1)
+RSpec.describe 'Tasks', type: :system do  
+  describe 'ログイン前' do
+    let(:user) { create(:user) }
+    let(:other_user) { create(:user) }
+    let(:task) { create(:task) }
+    let(:other_task) { create(:task, user_id: other_user.id) }
     
-      visit tasks_path
-      sleep 1
+    #==require_loginによるアクセス制限を検証==
+    describe 'ページ遷移(require_login)' do
 
-      # ログインしたユーザーが作成したタスクが表示されているか
-      expect(page).to have_content task_by_login_user.title
-      expect(page).to have_content task_by_login_user.content
-      expect(page).to have_content task_by_login_user.status
-      expect(page).to have_content task_by_login_user.deadline.strftime('%Y/%-m/%-d %-H:%-M')
+    #==require_loginでアクセスできないことを検証==
+      # before_action :require_login, only: %i[new edit]
+      context 'タスク新規作成ページへアクセス' do     
+        it 'タスク新規作成ページに遷移できない' do
+          visit new_task_path
+          sleep 1
+          expect(page).to have_content 'Login required'
+          expect(current_path).to eq login_path
+          sleep 1
+        end
+      end
+      
+      context 'タスク編集ページへアクセス' do
+        it 'タスク編集ページに遷移できない' do
+          visit edit_task_path(task)
+          sleep 1
+          expect(page).to have_content 'Login required'
+          expect(current_path).to eq login_path
+          sleep 1
+        end
+      end
+      
+    #==require_login対象外でアクセスできることを検証==
+      # before_action :require_login, only: %i[new edit]
+      context 'タスク詳細ページへアクセス' do
+        it 'タスク詳細ページに遷移できる' do
+          visit task_path(task)
+          sleep 1
+          expect(current_path).to eq task_path(task)
+          expect(page).to have_content task.title
+          expect(page).to have_content task.content
+          expect(page).to have_content task.status
+          expect(page).to have_content task.deadline.strftime('%Y/%-m/%-d %-H:%-M')
+          sleep 1
+        end
+      end
+      
+      context 'タスク一覧ページへアクセス' do
+        it 'タスク一覧ページに遷移できる' do
+          task 
+          other_task
+          # letでcreateしたtaskを呼び出す必要あり。
+
+          visit tasks_path
+
+          expect(page).to have_content task.title
+          expect(page).to have_content task.content
+          expect(page).to have_content task.status
+          expect(page).to have_content task.deadline.strftime('%Y/%-m/%-d %-H:%-M')
+
+          expect(page).to have_content other_task.title
+          expect(page).to have_content other_task.content
+          expect(page).to have_content other_task.status
+          expect(page).to have_content other_task.deadline.strftime('%Y/%-m/%-d %-H:%-M')
+        end
+      end
     end
-  end
-
-  describe '#create' do
-    it 'can create a new task' do
-      # ログインする
-      user = FactoryBot.create(:user)
-      login(user)
-      sleep 1
-
-      visit new_task_path
-
-      task = FactoryBot.build(:task)
-      fill_in 'Title', with: task.title
-      select task.status, from: 'Status'
-      click_button 'Create Task'
-      
-      expect(page).to have_content 'Task was successfully created.'
-      
-      expect(current_path).to eq task_path(task)
-      # ActionController::UrlGenerationError:
-      # No route matches {:action=>"show", :controller=>"tasks", :id=>nil}, missing required keys: [:id]
-    end
-  end
-
-  describe '#edit' do
-    it 'can edit a new task' do
-      # ログインする ===
-      user = FactoryBot.create(:user)
-      login(user)
-      sleep 1
-      # ===
-
-      # タスクを新規作成 ===
-      visit new_task_path
-      
-      task = FactoryBot.build(:task)
-      fill_in 'Title', with: task.title
-      select task.status, from: 'Status'
-      click_button 'Create Task'
-      # =====
-      
-      # 新規作成したタスクを編集 ===
-      visit edit_task_path(task)
-      
-      fill_in 'Title', with: 'ピアノ'
-      select task.status, from: 'Status'
-      sleep 1
-      click_button 'Update Task'
-      
-      expect(page).to have_content 'Task was successfully updated.'
-      
-      expect(current_path).to eq task_path(task)
-      # ===
-    end
-  end
+    
   
-  describe '#destroy' do
-    it 'can be deleted' do
-      # ログインする ===
-      user = FactoryBot.create(:user)
+  describe 'ログイン後' do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:task) { build(:task) }
+  let(:edit_task) {create(:task)}
+  let(:task_duplicated_title) { create(:task, title: task.title) }
+  let(:other_task) { create(:task, user_id: other_user.id) }
+    before do
       login(user)
-      sleep 1
-      # ===
-    
-      # タスクを新規作成 ===
-      visit new_task_path
-      
-      task = FactoryBot.build(:task)
-      fill_in 'Title', with: task.title
-      select task.status, from: 'Status'
-      click_button 'Create Task'
-      # =====
-      
-      # 新規作成したタスクを削除 ===
-      visit root_path
-      
-      click_link 'Destroy'
-
-      expect {
-        page.accept_confirm "Are you sure?"
-        expect(page).to have_content "Task was successfully destroyed."
-      }.to change { Task.count }.by(-1)
-
-      expect(page).to have_content 'Task was successfully destroyed.'
-      
-      expect(current_path).to eq tasks_path
-      # ===
     end
-  end
-  # ※task編集成功のテストコードに関して
-  # task = FactoryBot.create(:task) で作成したタスクを編集することとすると、user_idが一致しないユーザーがアクセスすることとなるため、アクセスできない。
-  # taskファクトリにuser_idを指定したら可か？
-  # ====
-  # task = FactoryBot.create(:task)      
-  # visit edit_task_path(task)
-  # fill_in 'Title', with: 'ピアノ'
-  # select task.status, from: 'Status'
-  # sleep 1
-  # click_button 'Update Task'    
-  # ===
-
-  describe 'require_login method test' do
-    context 'when not login' do
-      it 'cannot visit tasks/new' do
+    
+      describe 'タスク新規作成' do
+      before do
         visit new_task_path
         sleep 1
+      end
+
+        context 'フォームの入力値が正常' do
+          it 'タスク新規作成が成功する' do
+            fill_in 'Title', with: task.title
+            fill_in 'Content', with: task.content
+            select task.status, from: 'task_status'
+            fill_in 'Deadline', with: task.deadline
+            sleep 1
+            
+            click_button 'Create Task'
+            sleep 1
+
+            expect(page).to have_content 'Task was successfully created.'
+            expect(current_path).to eq '/tasks/1'
+            sleep 1
+          end
+        end
+
+        context 'タスクのタイトルが未入力' do
+          it 'タスク新規作成が失敗する' do
+            fill_in 'Title', with: ''
+            fill_in 'Content', with: task.content
+            select task.status, from: 'task_status'
+            fill_in 'Deadline', with: task.deadline
+            sleep 1
+            
+            click_button 'Create Task'
+            sleep 1
+
+            expect(page).to have_content "Title can't be blank"
+            expect(current_path).to eq tasks_path
+            sleep 1
+          end
+        end
+
+        context '登録済のタイトルを入力' do
+          it 'タスク新規作成が失敗する' do
+            task_duplicated_title
+            fill_in 'Title', with: task.title
+            fill_in 'Content', with: task.content
+            select task.status, from: 'task_status'
+            fill_in 'Deadline', with: task.deadline
+            sleep 1
+            
+            click_button 'Create Task'
+            sleep 1
+
+            expect(page).to have_content "Title has already been taken"
+            expect(current_path).to eq tasks_path
+            sleep 1
+          end
+        end
+      end
         
-        expect(page).to have_content 'Login required'
-        expect(current_path).to eq login_path
+        describe 'タスク編集' do
+          before do
+            task = create(:task, user_id: user.id)
+            visit edit_task_path(task)
+            sleep 1
+          end
+          
+          context 'フォームの入力値が正常' do
+            it 'タスクの編集が成功する' do
+              fill_in 'Title', with: 'Title edited'
+              fill_in 'Content', with: task.content
+              select task.status, from: 'task_status'
+              fill_in 'Deadline', with: task.deadline.strftime('%Y/%-m/%-d %-H:%-M')
+              sleep 1
+              
+              click_button 'Update'
+              sleep 1
+              
+              expect(page).to have_content 'Task was successfully updated.'
+              expect(current_path).to eq task_path(user)
+              sleep 1
+            end
+          end
+
+          context 'タスクのタイトルが未入力' do
+            it 'タスクの編集が失敗する' do
+              fill_in 'Title', with: ''
+              fill_in 'Content', with: task.content
+              select task.status, from: 'task_status'
+              fill_in 'Deadline', with: task.deadline
+              sleep 1
+              
+              click_button 'Update Task'
+              sleep 1
+              
+              expect(page).to have_content "Title can't be blank"
+              expect(current_path).to eq task_path(user)
+              sleep 1
+            end
+          end
+          
+          context '登録済のタイトルを使用' do
+            it 'タスクの編集が失敗する' do
+              fill_in 'Title', with: task_duplicated_title.title
+              sleep 1
+              
+              click_on 'Update Task'
+              sleep 1
+              
+              expect(page).to have_content "Title has already been taken"
+              expect(current_path).to eq task_path(user)
+              sleep 1
+            end
+          end
+
+        describe 'タスクの削除' do
+          context 'タスク一覧画面で' do 
+            it 'タスクの削除に成功する' do
+              visit tasks_path
+              click_on 'Destroy', match: :first
+              expect {
+                page.accept_confirm "Are you sure?"
+                expect(page).to have_content "Task was successfully destroyed."
+              }.to change { Task.count }.by(-1)
+            end
+          end
+          context 'マイページで' do
+            it 'タスクの削除に成功する' do
+              visit user_path(user)
+              click_on 'Destroy', match: :first
+              expect {
+                page.accept_confirm "Are you sure?"
+                expect(page).to have_content "Task was successfully destroyed."
+              }.to change { Task.count }.by(-1)
+            end
+          end
+        end
+
+        describe 'タスクの削除' do
+          context 'タスク一覧画面で' do 
+            it 'タスクの削除に成功する' do
+              visit tasks_path
+              click_on 'Destroy', match: :first
+              expect {
+                page.accept_confirm "Are you sure?"
+                expect(page).to have_content "Task was successfully destroyed."
+              }.to change { Task.count }.by(-1)
+            end
+          end
+          context 'マイページで' do
+            it 'タスクの削除に成功する' do
+              visit user_path(user)
+              click_on 'Destroy', match: :first
+              expect {
+                page.accept_confirm "Are you sure?"
+                expect(page).to have_content "Task was successfully destroyed."
+              }.to change { Task.count }.by(-1)
+            end
+          end
+        end
+
+        describe '他のユーザーが作成したタスクの操作' do
+          context '他のユーザーが作成したタスクの詳細ページにアクセス' do
+            it 'アクセスに失敗する' do
+            # verify_accessメソッドの検証
+                visit edit_task_path(other_task)
+                sleep 1
+                
+                expect(page).to have_content 'Forbidden access.'
+                expect(current_path).to eq root_path
+                sleep 1
+            end
+          end
+        end
       end
-
-      it 'cannot visit tasks/edit/:id' do
-        task = FactoryBot.create(:task)
-        visit edit_task_path(task)
-        sleep 1
-
-        expect(page).to have_content 'Login required'
-        expect(current_path).to eq login_path
-      end
-    end
-  end
-
-  describe '#verify_access' do
-    it 'cannot edit other task' do
-      other_user = FactoryBot.create(:other_user)
-      task = FactoryBot.create(:task)
-      
-      login(other_user)
-      sleep 1
-
-      visit edit_task_path(task)
-      sleep 1
-
-      expect(page).to have_content 'Forbidden access.'
-      expect(current_path).to eq root_path
     end
   end
 end
-

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -142,5 +142,20 @@ RSpec.describe "Tasks", type: :system do
     end
   end
 
+  describe '#verify_access' do
+    it 'cannot edit other task' do
+      other_user = FactoryBot.create(:other_user)
+      task = FactoryBot.create(:task)
+      
+      login(other_user)
+      sleep 1
+
+      visit edit_task_path(task)
+      sleep 1
+
+      expect(page).to have_content 'Forbidden access.'
+      expect(current_path).to eq root_path
+      end
+  end
 end
 

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -109,16 +109,38 @@ RSpec.describe "Tasks", type: :system do
       # ===
     end
   end
+  # ※task編集成功のテストコードに関して
+  # task = FactoryBot.create(:task) で作成したタスクを編集することとすると、user_idが一致しないユーザーがアクセスすることとなるため、アクセスできない。
+  # taskファクトリにuser_idを指定したら可か？
+  # ====
+  # task = FactoryBot.create(:task)      
+  # visit edit_task_path(task)
+  # fill_in 'Title', with: 'ピアノ'
+  # select task.status, from: 'Status'
+  # sleep 1
+  # click_button 'Update Task'    
+  # ===
+
+  describe 'require_login method test' do
+    context 'when not login' do
+      it 'cannot visit tasks/new' do
+        visit new_task_path
+        sleep 1
+        
+        expect(page).to have_content 'Login required'
+        expect(current_path).to eq login_path
+      end
+
+      it 'cannot visit tasks/edit/:id' do
+        task = FactoryBot.create(:task)
+        visit edit_task_path(task)
+        sleep 1
+
+        expect(page).to have_content 'Login required'
+        expect(current_path).to eq login_path
+      end
+    end
+  end
+
 end
 
-# ※task編集成功のテストコードに関して
-# task = FactoryBot.create(:task) で作成したタスクを編集することとすると、user_idが一致しないユーザーがアクセスすることとなるため、アクセスできない。
-# taskファクトリにuser_idを指定したら可か？
-# ====
-# task = FactoryBot.create(:task)      
-# visit edit_task_path(task)
-# fill_in 'Title', with: 'ピアノ'
-# select task.status, from: 'Status'
-# sleep 1
-# click_button 'Update Task'    
-# ===

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe "Tasks", type: :system do
 
       expect(page).to have_content 'Forbidden access.'
       expect(current_path).to eq root_path
-      end
+    end
   end
 end
 

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe 'UserSessions', type: :system do
+  describe 'ログイン前' do
+    context 'フォームの入力値が正常' do
+      it 'ログイン処理が成功する' do
+        login_user = FactoryBot.create(:user)
+        
+        visit login_path
+        sleep 1
+        
+        login(login_user)
+        sleep 1
+        
+        # post '/login', params: { user: FactoryBot.attributes_for(:user) }
+        # post :create, params: { user: FactoryBot.attributes_for(:user) }
+        # No match routesエラーが起こる
+        
+        # follow_redirect!
+        # not a redirectエラー
+        
+        expect(page).to have_content 'Login successful'
+        expect(current_path).to eq root_path
+      end
+    end
+
+    context 'フォームが未入力' do
+      it 'ログイン処理が失敗する' do
+        user = FactoryBot.create(:user)
+        
+        visit login_path
+        sleep 1
+        
+        fill_in 'Email', with: ''
+        fill_in 'Password', with: 'pwd'
+        click_button 'Login'
+        expect(page).to have_content 'Login failed'
+        expect(current_path).to eq login_path
+      end
+    end
+  end
+ 
+  describe 'ログイン後' do
+    context 'ログアウトボタンをクリック' do
+      it 'ログアウト処理が成功する' do 
+      end
+    end
+  end
+end

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -39,10 +39,20 @@ RSpec.describe 'UserSessions', type: :system do
       end
     end
   end
- 
+  
   describe 'ログイン後' do
     context 'ログアウトボタンをクリック' do
       it 'ログアウト処理が成功する' do 
+        user = FactoryBot.create(:user)
+        
+        login(user)
+        
+        click_link 'Logout'
+        sleep 1
+
+        expect(page).to have_content 'Logged out'
+        expect(current_path).to eq root_path
+        sleep 1
       end
     end
   end

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -5,20 +5,11 @@ RSpec.describe 'UserSessions', type: :system do
     let(:user) { create(:user) }
     describe 'ログイン前' do
       before do
-        # let!(:user) { create(:user) }
         visit login_path
         sleep 1
       end
       context 'フォームの入力値が正常' do
         it 'ログイン処理が成功する' do
-          
-          # post '/login', params: { user: FactoryBot.attributes_for(:user) }
-          # post :create, params: { user: FactoryBot.attributes_for(:user) }
-          # No match routesエラーが起こる
-          
-          # follow_redirect!
-          # not a redirectエラー
-          
           login(user)
           sleep 1
           expect(page).to have_content 'Login successful'
@@ -39,11 +30,6 @@ RSpec.describe 'UserSessions', type: :system do
     end
     
     describe 'ログイン後' do
-      # before do
-        # user = FactoryBot.create(:user)
-        
-        # login(user)
-      # end
       before do
         login(user)
       end

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -1,58 +1,62 @@
 require 'rails_helper'
 
 RSpec.describe 'UserSessions', type: :system do
-  describe 'ログイン前' do
-    context 'フォームの入力値が正常' do
-      it 'ログイン処理が成功する' do
-        login_user = FactoryBot.create(:user)
-        
+  describe 'ユーザーのログイン/ログアウト' do 
+    let(:user) { create(:user) }
+    describe 'ログイン前' do
+      before do
+        # let!(:user) { create(:user) }
         visit login_path
         sleep 1
-        
-        login(login_user)
-        sleep 1
-        
-        # post '/login', params: { user: FactoryBot.attributes_for(:user) }
-        # post :create, params: { user: FactoryBot.attributes_for(:user) }
-        # No match routesエラーが起こる
-        
-        # follow_redirect!
-        # not a redirectエラー
-        
-        expect(page).to have_content 'Login successful'
-        expect(current_path).to eq root_path
       end
-    end
+      context 'フォームの入力値が正常' do
+        it 'ログイン処理が成功する' do
+          
+          # post '/login', params: { user: FactoryBot.attributes_for(:user) }
+          # post :create, params: { user: FactoryBot.attributes_for(:user) }
+          # No match routesエラーが起こる
+          
+          # follow_redirect!
+          # not a redirectエラー
+          
+          login(user)
+          sleep 1
+          expect(page).to have_content 'Login successful'
+          expect(current_path).to eq root_path
+        end
+      end
 
-    context 'フォームが未入力' do
-      it 'ログイン処理が失敗する' do
-        user = FactoryBot.create(:user)
-        
-        visit login_path
-        sleep 1
-        
-        fill_in 'Email', with: ''
-        fill_in 'Password', with: 'pwd'
-        click_button 'Login'
-        expect(page).to have_content 'Login failed'
-        expect(current_path).to eq login_path
+      context 'フォームが未入力' do
+        it 'ログイン処理が失敗する' do
+          fill_in 'email', with: ''
+          sleep 3
+          fill_in 'Password', with: 'pwd'
+          click_button 'Login'
+          expect(page).to have_content 'Login failed'
+          expect(current_path).to eq login_path
+        end
       end
     end
-  end
-  
-  describe 'ログイン後' do
-    context 'ログアウトボタンをクリック' do
-      it 'ログアウト処理が成功する' do 
-        user = FactoryBot.create(:user)
+    
+    describe 'ログイン後' do
+      # before do
+        # user = FactoryBot.create(:user)
         
+        # login(user)
+      # end
+      before do
         login(user)
-        
-        click_link 'Logout'
-        sleep 1
+      end
+      context 'ログアウトボタンをクリック' do
+        it 'ログアウト処理が成功する' do 
+          
+          click_on 'Logout'
+          sleep 1
 
-        expect(page).to have_content 'Logged out'
-        expect(current_path).to eq root_path
-        sleep 1
+          expect(page).to have_content 'Logged out'
+          expect(current_path).to eq root_path
+          sleep 1
+        end
       end
     end
   end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -217,4 +217,20 @@ RSpec.describe "Users", type: :system do
       end
     end
   end
+  
+  describe '#verify_access' do
+    it 'cannot edit other user' do
+      user = FactoryBot.create(:user)
+      other_user = FactoryBot.create(:other_user)
+      
+      login(other_user)
+      sleep 1
+
+      visit edit_user_path(user)
+      sleep 1
+
+      expect(page).to have_content 'Forbidden access.'
+      expect(current_path).to eq user_path(other_user)
+      end
+  end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -105,6 +105,8 @@ RSpec.describe "Users", type: :system do
 
         expect(page).to have_content "Email can't be blank"
         expect(current_path).to eq users_path
+
+        expect(User.all.size).to eq 0
       end
     end
   end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -113,22 +113,62 @@ RSpec.describe "Users", type: :system do
       
       it 'fails to edit user' do
         user = FactoryBot.create(:user)
-
+        
         login(user)
         
         visit edit_user_path(user)
         sleep 1
-
+        
         fill_in 'Email', with: ''
         # 指定しない状態だと、予めフォームに入力されているメールアドレスがあるので空となっていない。
-
+        
         fill_in 'Password', with: 'edited_pwd'
         fill_in 'Password confirmation', with: 'edited_pwd'
         click_button 'Update'
         sleep 1
-
+        
         expect(page).to have_content "Email can't be blank"
         expect(current_path).to eq user_path(user)
+      end
+    end
+    
+    context 'when submit already registered email' do
+      it 'fails to create new user' do
+        user = FactoryBot.create(:user)
+        re_user = FactoryBot.build(:re_user)
+        
+        visit new_user_path
+        sleep 1
+        
+        fill_in 'Email', with: re_user.email
+        fill_in 'Password', with: 'pwd'
+        fill_in 'Password confirmation', with: 'pwd'
+        click_button 'SignUp'
+        sleep 1
+        
+        expect(page).to have_content "Email has already been taken"
+        expect(current_path).to eq users_path
+        
+        expect(User.all.size).to eq 1
+      end
+      
+      it 'fails to edit user' do
+        user = FactoryBot.create(:user)
+        re_user = FactoryBot.create(:re_user, email: 'hoge@example.com')
+        
+        login(re_user)
+        
+        visit edit_user_path(re_user)
+        sleep 1
+        
+        fill_in 'Email', with: user.email
+        fill_in 'Password', with: 'edited_pwd'
+        fill_in 'Password confirmation', with: 'edited_pwd'
+        click_button 'Update'
+        sleep 1
+        
+        expect(page).to have_content "Email has already been taken"
+        expect(current_path).to eq user_path(re_user)
       end
     end
   end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -65,28 +65,59 @@ RSpec.describe "Users", type: :system do
       end
     end
   end
-
-  describe 'login' do
-    context 'login success' do
+# 正常系
+  describe 'login success' do
+    context 'when complete all login-form' do
       it 'can login' do
         login_user = FactoryBot.create(:user)
-
+        
         visit login_path
         sleep 1
-
+        
         login(login_user)
         sleep 1
-
+        
         # post '/login', params: { user: FactoryBot.attributes_for(:user) }
         # post :create, params: { user: FactoryBot.attributes_for(:user) }
         # No match routesエラーが起こる
         
         # follow_redirect!
         # not a redirectエラー
-
+        
         expect(page).to have_content 'Login successful'
         expect(current_path).to eq root_path
+        
+      end
+    end
+  end
+  
+  # 異常系
+  describe 'login failure' do
+    context 'when blank login-form exists' do
+      it 'when email is brank' do
+        user = FactoryBot.create(:user)
+        
+        visit login_path
+        sleep 1
+        
+        fill_in 'Email', with: ''
+        fill_in 'Password', with: 'pwd'
+        click_button 'Login'
+        expect(page).to have_content 'Login failed'
+        expect(current_path).to eq login_path
+      end
 
+      it 'when password is brank' do
+        user = FactoryBot.create(:user)
+        
+        visit login_path
+        sleep 1
+        
+        fill_in 'Email', with: user.email
+        fill_in 'Password', with: ''
+        click_button 'Login'
+        expect(page).to have_content 'Login failed'
+        expect(current_path).to eq login_path
       end
     end
   end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,236 +1,208 @@
 require 'rails_helper'
 
-RSpec.describe "Users", type: :system do
-  # 正常系
-  describe 'UsersController#create' do
-    context 'user registration' do
-      it 'can be created' do
-        new_user = FactoryBot.build(:user)
+RSpec.describe 'Users', type: :system do
+  describe 'ログイン前' do
+    describe 'ユーザー新規登録' do
+      context 'フォームの入力値が正常' do
+        it 'ユーザーの新規作成が成功する' do
+          new_user = FactoryBot.build(:user)
 
-        visit new_user_path
-        sleep 1
+          visit new_user_path
+          sleep 1
 
-        fill_in 'Email', with: new_user.email
-        fill_in "Password", with: 'pwd'
-        # fill_in "Password", with: new_user.password では入力されない
-        # sorceryでは「password」はvirtual attribute(DBに存在しない)→ActiveRecordメソッドで呼び出せない。
-        fill_in 'Password confirmation', with: 'pwd'
-        # fill_in "Password confirmation", with: new_user.password_confirmation では入力されない
-        # sorceryでは「password_confirmation」はvirtual attribute(DBに存在しない)→ActiveRecordメソッドで呼び出せない。
+          fill_in 'Email', with: new_user.email
+          fill_in "Password", with: 'password'
+          # fill_in "Password", with: new_user.password では入力されない
+          # sorceryでは「password」はvirtual attribute(DBに存在しない)→ActiveRecordメソッドで呼び出せない。
+          fill_in 'Password confirmation', with: 'password'
+          # fill_in "Password confirmation", with: new_user.password_confirmation では入力されない
+          # sorceryでは「password_confirmation」はvirtual attribute(DBに存在しない)→ActiveRecordメソッドで呼び出せない。
+          
+          sleep 1
+
+          click_button 'SignUp'
+
+          sleep 1
+
+          expect(page).to have_content 'User was successfully created.'
+          expect(current_path).to eq login_path
+        end
+      end
+
+      context 'メールアドレスが未入力' do
+        it 'ユーザーの新規作成が失敗する' do
+          user = FactoryBot.build(:user)
+
+          visit new_user_path
+          sleep 1
         
-        sleep 1
+          fill_in 'Password', with: 'password'
+          fill_in 'Password confirmation', with: 'password'
+          click_button 'SignUp'
+          sleep 1
 
-        click_button 'SignUp'
+          expect(page).to have_content "Email can't be blank"
+          expect(current_path).to eq users_path
+        
+          expect(User.all.size).to eq 0
+        end
+      end
 
-        sleep 1
-
-        expect(page).to have_content 'User was successfully created.'
-        expect(current_path).to eq login_path
+      context '登録済のメールアドレスを使用' do
+        it 'ユーザーの新規作成が失敗する' do
+          user = FactoryBot.create(:user)
+          re_user = FactoryBot.build(:re_user)
+        
+          visit new_user_path
+          sleep 1
+        
+          fill_in 'Email', with: re_user.email
+          fill_in 'Password', with: 'pwd'
+          fill_in 'Password confirmation', with: 'pwd'
+          click_button 'SignUp'
+          sleep 1
+        
+          expect(page).to have_content "Email has already been taken"
+          expect(current_path).to eq users_path
+        
+          expect(User.all.size).to eq 1
+        end
       end
     end
   end
-  
-  describe 'UsersController#edit' do
-    context 'editing user' do
-      it 'can be edited' do
+ 
+    describe 'マイページ' do
+      context 'ログインしていない状態' do
+        it 'マイページへのアクセスが失敗する' do
+          user = FactoryBot.create(:user)
 
-        editing_user = FactoryBot.create(:user)
-        # editing_user = FactoryBot.build(:user)ではDB上にレコード登録されていないのでログイン情報として使用不可
-
-        # 編集するにはbefore_action :require_loginを通る必要がある
-
-        login(editing_user)
-
-        sleep 3
+          visit user_path(user)
+          sleep 1
         
-        visit edit_user_path(editing_user)
-        sleep 1
-
-        fill_in 'Email', with: editing_user.email
-        fill_in "Password", with: 'edited_pwd'
-        fill_in 'Password confirmation', with: 'edited_pwd'
-        
-        sleep 1
-
-        click_button 'Update'
-
-        sleep 1
-
-        expect(page).to have_content 'User was successfully updated.'
-
-        expect(current_path).to eq user_path(editing_user)
-        # 編集前のユーザーファクトリをediting_user, 編集後のユーザーファクトリをedited_userと区別すると、idが異なってしまうため、詳細画面のパスエラー（ActionController::UrlGenerationError:No route matches）となる。区別する必要なし。
-
-        sleep 1
+          expect(page).to have_content 'Login required'
+          expect(current_path).to eq login_path
+        end
       end
     end
-  end
-# 正常系
-  describe 'login success' do
-    context 'when complete all login-form' do
-      it 'can login' do
-        login_user = FactoryBot.create(:user)
-        
-        visit login_path
-        sleep 1
-        
-        login(login_user)
-        sleep 1
-        
-        # post '/login', params: { user: FactoryBot.attributes_for(:user) }
-        # post :create, params: { user: FactoryBot.attributes_for(:user) }
-        # No match routesエラーが起こる
-        
-        # follow_redirect!
-        # not a redirectエラー
-        
-        expect(page).to have_content 'Login successful'
-        expect(current_path).to eq root_path
-        
-      end
-    end
-  end
-  
-  # 異常系
-  describe 'login failure' do
-    context 'when blank login-form exists' do
-      it 'when email is brank' do
-        user = FactoryBot.create(:user)
-        
-        visit login_path
-        sleep 1
-        
-        fill_in 'Email', with: ''
-        fill_in 'Password', with: 'pwd'
-        click_button 'Login'
-        expect(page).to have_content 'Login failed'
-        expect(current_path).to eq login_path
-      end
+ 
+  describe 'ログイン後' do
+    describe 'ユーザー編集' do
+      context 'フォームの入力値が正常' do
+        it 'ユーザーの編集が成功する' do
+          
+          editing_user = FactoryBot.create(:user)
+          # editing_user = FactoryBot.build(:user)ではDB上にレコード登録されていないのでログイン情報として使用不可
 
-      it 'when password is brank' do
-        user = FactoryBot.create(:user)
+          # 編集するにはbefore_action :require_loginを通る必要がある
+
+          login(editing_user)
+
+          sleep 3
         
-        visit login_path
-        sleep 1
+          visit edit_user_path(editing_user)
+          sleep 1
+
+          fill_in 'Email', with: editing_user.email
+          fill_in "Password", with: 'edited_pwd'
+          fill_in 'Password confirmation', with: 'edited_pwd'
         
-        fill_in 'Email', with: user.email
-        fill_in 'Password', with: ''
-        click_button 'Login'
-        expect(page).to have_content 'Login failed'
-        expect(current_path).to eq login_path
+          sleep 1
+
+          click_button 'Update'
+
+          sleep 1
+
+          expect(page).to have_content 'User was successfully updated.'
+
+          expect(current_path).to eq user_path(editing_user)
+          # 編集前のユーザーファクトリをediting_user, 編集後のユーザーファクトリをedited_userと区別すると、idが異なってしまうため、詳細画面のパスエラー（ActionController::UrlGenerationError:No route matches）となる。区別する必要なし。
+
+          sleep 1
+
+        end
       end
     end
   end
 
-  #異常系
-  describe "user's email validation" do
-    context 'when email is blank' do
-      it 'fails to registate new user' do
-        user = FactoryBot.build(:user)
-
-        visit new_user_path
-        sleep 1
+      context 'メールアドレスが未入力' do
+        it 'ユーザーの編集が失敗する' do 
+          user = FactoryBot.create(:user)
         
-        fill_in 'Password', with: 'pwd'
-        fill_in 'Password confirmation', with: 'pwd'
-        click_button 'SignUp'
-        sleep 1
-
-        expect(page).to have_content "Email can't be blank"
-        expect(current_path).to eq users_path
-        
-        expect(User.all.size).to eq 0
+          login(user)
+          
+          visit edit_user_path(user)
+          sleep 1
+          
+          fill_in 'Email', with: ''
+          # 指定しない状態だと、予めフォームに入力されているメールアドレスがあるので空となっていない。
+          
+          fill_in 'Password', with: 'edited_pwd'
+          fill_in 'Password confirmation', with: 'edited_pwd'
+          click_button 'Update'
+          sleep 1
+          
+          expect(page).to have_content "Email can't be blank"
+          expect(current_path).to eq user_path(user)
+        end
       end
+
+      context '登録済のメールアドレスを使用' do
+        it 'ユーザーの編集が失敗する' do
+          user = FactoryBot.create(:user)
+          re_user = FactoryBot.create(:re_user, email: 'hoge@example.com')
+          
+          login(re_user)
+          
+          visit edit_user_path(re_user)
+          sleep 1
+          
+          fill_in 'Email', with: user.email
+          fill_in 'Password', with: 'edited_pwd'
+          fill_in 'Password confirmation', with: 'edited_pwd'
+          click_button 'Update'
+          sleep 1
+          
+          expect(page).to have_content "Email has already been taken"
+          expect(current_path).to eq user_path(re_user)
+        end
+      end
+
+      context '他ユーザーの編集ページにアクセス' do
+        it '編集ページへのアクセスが失敗する' do
+          user = FactoryBot.create(:user)
+          other_user = FactoryBot.create(:other_user)
       
-      it 'fails to edit user' do
-        user = FactoryBot.create(:user)
-        
-        login(user)
-        
-        visit edit_user_path(user)
-        sleep 1
-        
-        fill_in 'Email', with: ''
-        # 指定しない状態だと、予めフォームに入力されているメールアドレスがあるので空となっていない。
-        
-        fill_in 'Password', with: 'edited_pwd'
-        fill_in 'Password confirmation', with: 'edited_pwd'
-        click_button 'Update'
-        sleep 1
-        
-        expect(page).to have_content "Email can't be blank"
-        expect(current_path).to eq user_path(user)
+          login(other_user)
+          sleep 1
+
+          visit edit_user_path(user)
+          sleep 1
+
+          expect(page).to have_content 'Forbidden access.'
+          expect(current_path).to eq user_path(other_user)
+        end
       end
-    end
+ 
+    describe 'マイページ' do
+      context 'タスクを作成' do
+        it '新規作成したタスクが表示される' do
+          # ログインする
+          login_user = FactoryBot.create(:user) # id=1のuser
+          login(login_user)
+          sleep 1
+
+          # login_userが作成したタスクを用意
+          task_by_login_user = FactoryBot.create(:task, user_id: 1)
     
-    context 'when submit already registered email' do
-      it 'fails to create new user' do
-        user = FactoryBot.create(:user)
-        re_user = FactoryBot.build(:re_user)
-        
-        visit new_user_path
-        sleep 1
-        
-        fill_in 'Email', with: re_user.email
-        fill_in 'Password', with: 'pwd'
-        fill_in 'Password confirmation', with: 'pwd'
-        click_button 'SignUp'
-        sleep 1
-        
-        expect(page).to have_content "Email has already been taken"
-        expect(current_path).to eq users_path
-        
-        expect(User.all.size).to eq 1
-      end
-      
-      it 'fails to edit user' do
-        user = FactoryBot.create(:user)
-        re_user = FactoryBot.create(:re_user, email: 'hoge@example.com')
-        
-        login(re_user)
-        
-        visit edit_user_path(re_user)
-        sleep 1
-        
-        fill_in 'Email', with: user.email
-        fill_in 'Password', with: 'edited_pwd'
-        fill_in 'Password confirmation', with: 'edited_pwd'
-        click_button 'Update'
-        sleep 1
-        
-        expect(page).to have_content "Email has already been taken"
-        expect(current_path).to eq user_path(re_user)
+          visit tasks_path
+          sleep 1
+
+          # ログインしたユーザーが作成したタスクが表示されているか
+          expect(page).to have_content task_by_login_user.title
+          expect(page).to have_content task_by_login_user.content
+          expect(page).to have_content task_by_login_user.status
+          expect(page).to have_content task_by_login_user.deadline.strftime('%Y/%-m/%-d %-H:%-M')
+        end
       end
     end
   end
-
-  describe 'require_login method test' do
-    context 'when not login' do
-      it 'cannot visit users/edit/:id' do
-        user = FactoryBot.create(:user)
-
-        visit user_path(user)
-        sleep 1
-        
-        expect(page).to have_content 'Login required'
-        expect(current_path).to eq login_path
-      end
-    end
-  end
-  
-  describe '#verify_access' do
-    it 'cannot edit other user' do
-      user = FactoryBot.create(:user)
-      other_user = FactoryBot.create(:other_user)
-      
-      login(other_user)
-      sleep 1
-
-      visit edit_user_path(user)
-      sleep 1
-
-      expect(page).to have_content 'Forbidden access.'
-      expect(current_path).to eq user_path(other_user)
-      end
-  end
-end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "Users", type: :system do
+  # 正常系
   describe 'UsersController#create' do
     context 'user registration' do
       it 'can be created' do
@@ -86,6 +87,24 @@ RSpec.describe "Users", type: :system do
         expect(page).to have_content 'Login successful'
         expect(current_path).to eq root_path
 
+      end
+    end
+  end
+
+  #異常系
+  describe 'user attribute validation' do
+    context 'when email is blank' do
+      it 'fails to registate new user' do
+        user = FactoryBot.build(:user)
+
+        visit new_user_path
+
+        fill_in 'Password', with: 'pwd'
+        fill_in 'Password confirmation', with: 'pwd'
+        click_button 'SignUp'
+
+        expect(page).to have_content "Email can't be blank"
+        expect(current_path).to eq users_path
       end
     end
   end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -203,4 +203,18 @@ RSpec.describe "Users", type: :system do
       end
     end
   end
+
+  describe 'require_login method test' do
+    context 'when not login' do
+      it 'cannot visit users/edit/:id' do
+        user = FactoryBot.create(:user)
+
+        visit user_path(user)
+        sleep 1
+        
+        expect(page).to have_content 'Login required'
+        expect(current_path).to eq login_path
+      end
+    end
+  end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -92,21 +92,43 @@ RSpec.describe "Users", type: :system do
   end
 
   #異常系
-  describe 'user attribute validation' do
+  describe "user's email validation" do
     context 'when email is blank' do
       it 'fails to registate new user' do
         user = FactoryBot.build(:user)
 
         visit new_user_path
-
+        sleep 1
+        
         fill_in 'Password', with: 'pwd'
         fill_in 'Password confirmation', with: 'pwd'
         click_button 'SignUp'
+        sleep 1
 
         expect(page).to have_content "Email can't be blank"
         expect(current_path).to eq users_path
-
+        
         expect(User.all.size).to eq 0
+      end
+      
+      it 'fails to edit user' do
+        user = FactoryBot.create(:user)
+
+        login(user)
+        
+        visit edit_user_path(user)
+        sleep 1
+
+        fill_in 'Email', with: ''
+        # 指定しない状態だと、予めフォームに入力されているメールアドレスがあるので空となっていない。
+
+        fill_in 'Password', with: 'edited_pwd'
+        fill_in 'Password confirmation', with: 'edited_pwd'
+        click_button 'Update'
+        sleep 1
+
+        expect(page).to have_content "Email can't be blank"
+        expect(current_path).to eq user_path(user)
       end
     end
   end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe 'Users', type: :system do
     describe 'ユーザー新規登録' do
       context 'フォームの入力値が正常' do
         it 'ユーザーの新規作成が成功する' do
-          new_user = FactoryBot.build(:user)
+          user = build(:user)
 
           visit new_user_path
           sleep 1
 
-          fill_in 'Email', with: new_user.email
+          fill_in 'Email', with: user.email
           fill_in "Password", with: 'password'
           # fill_in "Password", with: new_user.password では入力されない
           # sorceryでは「password」はvirtual attribute(DBに存在しない)→ActiveRecordメソッドで呼び出せない。
@@ -31,7 +31,7 @@ RSpec.describe 'Users', type: :system do
 
       context 'メールアドレスが未入力' do
         it 'ユーザーの新規作成が失敗する' do
-          user = FactoryBot.build(:user)
+          user = build(:user)
 
           visit new_user_path
           sleep 1
@@ -50,8 +50,8 @@ RSpec.describe 'Users', type: :system do
 
       context '登録済のメールアドレスを使用' do
         it 'ユーザーの新規作成が失敗する' do
-          user = FactoryBot.create(:user)
-          re_user = FactoryBot.build(:re_user)
+          user = create(:user)
+          re_user = build(:user)
         
           visit new_user_path
           sleep 1
@@ -74,7 +74,7 @@ RSpec.describe 'Users', type: :system do
     describe 'マイページ' do
       context 'ログインしていない状態' do
         it 'マイページへのアクセスが失敗する' do
-          user = FactoryBot.create(:user)
+          user = create(:user)
 
           visit user_path(user)
           sleep 1
@@ -90,7 +90,7 @@ RSpec.describe 'Users', type: :system do
       context 'フォームの入力値が正常' do
         it 'ユーザーの編集が成功する' do
           
-          editing_user = FactoryBot.create(:user)
+          editing_user = create(:user)
           # editing_user = FactoryBot.build(:user)ではDB上にレコード登録されていないのでログイン情報として使用不可
 
           # 編集するにはbefore_action :require_loginを通る必要がある
@@ -126,7 +126,7 @@ RSpec.describe 'Users', type: :system do
 
       context 'メールアドレスが未入力' do
         it 'ユーザーの編集が失敗する' do 
-          user = FactoryBot.create(:user)
+          user = create(:user)
         
           login(user)
           
@@ -148,8 +148,8 @@ RSpec.describe 'Users', type: :system do
 
       context '登録済のメールアドレスを使用' do
         it 'ユーザーの編集が失敗する' do
-          user = FactoryBot.create(:user)
-          re_user = FactoryBot.create(:re_user, email: 'hoge@example.com')
+          user = create(:user)
+          re_user = create(:re_user, email: 'hoge@example.com')
           
           login(re_user)
           
@@ -169,8 +169,8 @@ RSpec.describe 'Users', type: :system do
 
       context '他ユーザーの編集ページにアクセス' do
         it '編集ページへのアクセスが失敗する' do
-          user = FactoryBot.create(:user)
-          other_user = FactoryBot.create(:other_user)
+          user = create(:user)
+          other_user = create(:other_user)
       
           login(other_user)
           sleep 1
@@ -187,12 +187,12 @@ RSpec.describe 'Users', type: :system do
       context 'タスクを作成' do
         it '新規作成したタスクが表示される' do
           # ログインする
-          login_user = FactoryBot.create(:user) # id=1のuser
-          login(login_user)
+          user = create(:user) # id=1のuser
+          login(user)
           sleep 1
 
           # login_userが作成したタスクを用意
-          task_by_login_user = FactoryBot.create(:task, user_id: 1)
+          task_by_login_user = create(:task, user_id: 1)
     
           visit tasks_path
           sleep 1

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,138 +1,118 @@
 require 'rails_helper'
 
-RSpec.describe 'Users', type: :system do
+RSpec.describe 'Users', type: :system do  
   describe 'ログイン前' do
+    let(:user) { build(:user) }
+    let(:other_user) { build(:user)}
     describe 'ユーザー新規登録' do
-      context 'フォームの入力値が正常' do
+    before do
+      visit new_user_path
+      sleep 1
+    end
+      context 'フォームの入力値が正常' do     
         it 'ユーザーの新規作成が成功する' do
-          user = build(:user)
-
-          visit new_user_path
-          sleep 1
-
           fill_in 'Email', with: user.email
           fill_in "Password", with: 'password'
-          # fill_in "Password", with: new_user.password では入力されない
-          # sorceryでは「password」はvirtual attribute(DBに存在しない)→ActiveRecordメソッドで呼び出せない。
           fill_in 'Password confirmation', with: 'password'
-          # fill_in "Password confirmation", with: new_user.password_confirmation では入力されない
-          # sorceryでは「password_confirmation」はvirtual attribute(DBに存在しない)→ActiveRecordメソッドで呼び出せない。
+          sleep 1
           
-          sleep 1
-
           click_button 'SignUp'
-
           sleep 1
-
+          
           expect(page).to have_content 'User was successfully created.'
           expect(current_path).to eq login_path
+          sleep 1
         end
       end
-
+      
       context 'メールアドレスが未入力' do
         it 'ユーザーの新規作成が失敗する' do
-          user = build(:user)
-
-          visit new_user_path
-          sleep 1
-        
           fill_in 'Password', with: 'password'
           fill_in 'Password confirmation', with: 'password'
           click_button 'SignUp'
           sleep 1
-
+          
           expect(page).to have_content "Email can't be blank"
           expect(current_path).to eq users_path
-        
           expect(User.all.size).to eq 0
+          sleep 1
         end
       end
-
+      
       context '登録済のメールアドレスを使用' do
         it 'ユーザーの新規作成が失敗する' do
-          user = create(:user)
-          re_user = build(:user)
-        
-          visit new_user_path
-          sleep 1
-        
-          fill_in 'Email', with: re_user.email
-          fill_in 'Password', with: 'pwd'
-          fill_in 'Password confirmation', with: 'pwd'
+          fill_in 'Email', with: user.email
+          fill_in 'Password', with: 'password'
+          fill_in 'Password confirmation', with: 'password'
           click_button 'SignUp'
           sleep 1
-        
+          
+          click_on 'SignUp'
+          sleep 1
+
+          fill_in 'Email', with: user.email
+          fill_in 'Password', with: 'password'
+          fill_in 'Password confirmation', with: 'password'
+          click_button 'SignUp'
+          sleep 1
+          
           expect(page).to have_content "Email has already been taken"
           expect(current_path).to eq users_path
-        
           expect(User.all.size).to eq 1
+          sleep 1
         end
       end
     end
-  end
- 
+    
     describe 'マイページ' do
+      let(:user) { create(:user) }
+      before do
+        visit user_path(user)
+        sleep 1
+      end
       context 'ログインしていない状態' do
         it 'マイページへのアクセスが失敗する' do
-          user = create(:user)
-
-          visit user_path(user)
-          sleep 1
-        
           expect(page).to have_content 'Login required'
           expect(current_path).to eq login_path
         end
       end
     end
- 
+  end
+  
   describe 'ログイン後' do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:task) { build(:task) }
+  before do
+    login(user)
+  end
+  
     describe 'ユーザー編集' do
+    before do
+      visit user_path(user)
+      click_on 'Edit'
+      sleep 1
+    end
+
       context 'フォームの入力値が正常' do
         it 'ユーザーの編集が成功する' do
-          
-          editing_user = create(:user)
-          # editing_user = FactoryBot.build(:user)ではDB上にレコード登録されていないのでログイン情報として使用不可
-
-          # 編集するにはbefore_action :require_loginを通る必要がある
-
-          login(editing_user)
-
-          sleep 3
-        
-          visit edit_user_path(editing_user)
-          sleep 1
-
-          fill_in 'Email', with: editing_user.email
+          fill_in 'Email', with: user.email
           fill_in "Password", with: 'edited_pwd'
           fill_in 'Password confirmation', with: 'edited_pwd'
-        
           sleep 1
-
+          
           click_button 'Update'
-
           sleep 1
 
           expect(page).to have_content 'User was successfully updated.'
 
-          expect(current_path).to eq user_path(editing_user)
-          # 編集前のユーザーファクトリをediting_user, 編集後のユーザーファクトリをedited_userと区別すると、idが異なってしまうため、詳細画面のパスエラー（ActionController::UrlGenerationError:No route matches）となる。区別する必要なし。
-
+          expect(current_path).to eq user_path(user)
           sleep 1
-
         end
       end
-    end
-  end
 
       context 'メールアドレスが未入力' do
         it 'ユーザーの編集が失敗する' do 
-          user = create(:user)
-        
-          login(user)
-          
-          visit edit_user_path(user)
-          sleep 1
-          
           fill_in 'Email', with: ''
           # 指定しない状態だと、予めフォームに入力されているメールアドレスがあるので空となっていない。
           
@@ -148,30 +128,20 @@ RSpec.describe 'Users', type: :system do
 
       context '登録済のメールアドレスを使用' do
         it 'ユーザーの編集が失敗する' do
-          user = create(:user)
-          re_user = create(:re_user, email: 'hoge@example.com')
-          
-          login(re_user)
-          
-          visit edit_user_path(re_user)
-          sleep 1
-          
-          fill_in 'Email', with: user.email
-          fill_in 'Password', with: 'edited_pwd'
-          fill_in 'Password confirmation', with: 'edited_pwd'
+          fill_in 'Email', with: other_user.email
+          fill_in 'Password', with: 'password'
+          fill_in 'Password confirmation', with: 'password'
           click_button 'Update'
           sleep 1
           
           expect(page).to have_content "Email has already been taken"
-          expect(current_path).to eq user_path(re_user)
+          expect(current_path).to eq user_path(user)
         end
       end
+    end
 
       context '他ユーザーの編集ページにアクセス' do
         it '編集ページへのアクセスが失敗する' do
-          user = create(:user)
-          other_user = create(:other_user)
-      
           login(other_user)
           sleep 1
 
@@ -182,27 +152,32 @@ RSpec.describe 'Users', type: :system do
           expect(current_path).to eq user_path(other_user)
         end
       end
- 
+    
+      
     describe 'マイページ' do
+    before do
+      visit new_task_path
+    end
+        
       context 'タスクを作成' do
         it '新規作成したタスクが表示される' do
-          # ログインする
-          user = create(:user) # id=1のuser
-          login(user)
-          sleep 1
-
-          # login_userが作成したタスクを用意
-          task_by_login_user = create(:task, user_id: 1)
-    
+          
+          fill_in 'Title', with: task.title
+          fill_in 'Content', with: task.content
+          select task.status, from: 'task_status'
+          fill_in 'Deadline', with: task.deadline
+          click_on 'Create Task'
+          
           visit tasks_path
           sleep 1
-
+          
           # ログインしたユーザーが作成したタスクが表示されているか
-          expect(page).to have_content task_by_login_user.title
-          expect(page).to have_content task_by_login_user.content
-          expect(page).to have_content task_by_login_user.status
-          expect(page).to have_content task_by_login_user.deadline.strftime('%Y/%-m/%-d %-H:%-M')
+          expect(page).to have_content task.title
+          expect(page).to have_content task.content
+          expect(page).to have_content task.status
+          expect(page).to have_content task.deadline.strftime('%Y/%-m/%-d %-H:%-M')
         end
       end
     end
   end
+end


### PR DESCRIPTION
SystemSpecをModelSpec的記述で書いていたため、修正
## ①テスト構成の修正
## ②共通の前処理をまとめて記述（リファクタリング）
```Ruby
before do
  #===共通の前処理===
end
```
## ③```let```を使用
・テストケース内でフォーム入力で新規作成するデータ → ```let(:user) { build(:user) }```で記述
・テストケース内でフォーム入力で新規作成しないデータ → ```let(:user) { create(:user) }```で記述
## ③ファクトリデータ生成に省略記法使用
## ④ファクトリデータの生成コードを修正
・```sequence```を使用した連番データの生成
・ファクトリデータのシンボルを１つに統一
```
user = create(:user)
other_user = create(:other_user)
```
↓
```
user = create(:user)
other_user = create(:user)
```